### PR TITLE
Add zones to the registry by default

### DIFF
--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -588,7 +588,7 @@ class AmpliPiZone(MediaPlayerEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return if the entity should be enabled when first added to the entity registry."""
-        return False
+        return True
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
When adding my (new!) Amplipi to home assistant, the sources worked but not the zones.  I found that changing this value before adding my amplipi entries fixed the problem for me.  Otherwise, the zones just stayed disabled forever.

It seems like the code is expecting the async_update to run and mark the zones as enabled, but it's never getting called when the zones are disabled (in my experience anyway)