### PR TITLE
Update to new AmpliPi zeroconf structure

### DIFF
--- a/custom_components/amplipi/config_flow.py
+++ b/custom_components/amplipi/config_flow.py
@@ -43,6 +43,19 @@ async def async_retrieve_info(hass, host, port):
         _LOGGER.error("Timed out when connecting to AmpliPi Controller")
         raise
 
+def is_private_ip(ip: str) -> bool:
+    """ Check if an ip is from a private network
+    We prefer standard private networks."""
+    return ip.startswith('192.') or ip.startswith('10.')
+
+def preferred_host(info: zeroconf.ZeroconfServiceInfo) -> str:
+    """ AmpliPi can advertise several IPs (thanks docker!)
+    Prefer a private network like 192. or 10."""
+    host = info.host
+    private_ips = [ip for ip in info.addresses if is_private_ip(ip)]
+    if not is_private_ip(info.host) and len(private_ips) > 0:
+        host = private_ips[0]
+    return host
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for AmpliPi."""
@@ -150,12 +163,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_zeroconf(self, discovery_info: zeroconf.ZeroconfServiceInfo):
         """Handle zeroconf discovery."""
         _LOGGER.info("discovered %s", discovery_info)
-        self._controller_hostname = discovery_info.host
+        self._controller_hostname = preferred_host(discovery_info)
         self._controller_port = discovery_info.port
         self._name = discovery_info.properties['name']
         self._vendor = discovery_info.properties['vendor']
         self._version = discovery_info.properties['version']
-        self._uuid = discovery_info.properties['name']  # this is not right.  we need a uuid
+        self._uuid = discovery_info.name
         self._webapp_url = discovery_info.properties['web_app']
         self._api_path = discovery_info.properties['path']
 

--- a/custom_components/amplipi/manifest.json
+++ b/custom_components/amplipi/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/amplipi",
   "requirements": ["zeroconf","pyamplipi==0.4.9","validators"],
   "ssdp": [],
-  "zeroconf": [{ "type": "_http._tcp.local.", "name": "amplipi-api._http._tcp.local."}],
+  "zeroconf": ["_amplipi._tcp.local."],
   "homekit": {},
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
This updates this plugin to use the newer `_amplipi._tcp.local.` advertisement and enables each AmpliPi on the network to have a unique id.

Back in 0.1.7 we deprecated our old `_http._tcp.local.` zeroconf advertisement and added `_amplipi._tcp.local.` that adds the AmpliPi's MAC address into the name. 

This also adds some filtering on the ip address given. Some of our development AmpliPis have docker installed on them which makes our zeroconf advertisement have multiple ip addresses one of which is invalid externally.  