### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/amplipi/config_flow.py
+++ b/custom_components/amplipi/config_flow.py
@@ -30,7 +30,7 @@ async def async_retrieve_info(hass, host, port):
     try:
         with async_timeout.timeout(5000):
             client = AmpliPi(
-                f"http://{host}:{port}/api/",
+                f"http://{host}:{port}/api",
                 10,
                 session
             )


### PR DESCRIPTION
It appears that the path has been updated in 0.3.0 to no longer accept the trailing / on the api path. When going to amplipi:80/api/ you get a json body that says not found.

I've reverted my instance to 0.2.1 and can confirm that amplipi:80/api works without the last forward slash

Or to put it another way: 

v0.2.1 amplipi.local/api and amplipi.local/api/ both work.
v0.3.0 amplip.local/api works and amplipi.local/api/ does not work. 